### PR TITLE
fix: replace NodeJS timeout type with generic browser-friendly type

### DIFF
--- a/src/components/CoverCanvas.tsx
+++ b/src/components/CoverCanvas.tsx
@@ -43,7 +43,9 @@ export const CoverCanvas = forwardRef<CoverCanvasRef, CoverCanvasProps>(
     const [isLoading, setIsLoading] = useState(false);
     const [loadError, setLoadError] = useState(false);
     const [errorMessage, setErrorMessage] = useState("");
-    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+    // setTimeout の戻り値は環境によって型が異なるため
+    // Node.js 固有の型ではなく汎用的な型を使用する
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const downloadImage = () => {
       const canvas = canvasRef.current;


### PR DESCRIPTION
## Summary
- avoid Node.js specific `NodeJS.Timeout` type in CoverCanvas debounce timer
- use `ReturnType<typeof setTimeout>` to improve cross-platform compatibility

## Testing
- `pnpm type-check`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_68bd33f134908329b3720108b62ccb97